### PR TITLE
写真追加 and 撮影して保存

### DIFF
--- a/GourmetSearch.xcodeproj/project.pbxproj
+++ b/GourmetSearch.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		8E2625B81FCDBD4C0041010B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8E2625B61FCDBD4C0041010B /* Main.storyboard */; };
 		8E2625BA1FCDBD4C0041010B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E2625B91FCDBD4C0041010B /* Assets.xcassets */; };
 		8E2625BD1FCDBD4C0041010B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8E2625BB1FCDBD4C0041010B /* LaunchScreen.storyboard */; };
+		8E79CEE51FF5E292001957B3 /* ShopPhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E79CEE41FF5E292001957B3 /* ShopPhoto.swift */; };
 		8E8AE85F1FE65A6B0015D415 /* SearchTopTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8AE85E1FE65A6B0015D415 /* SearchTopTableViewController.swift */; };
 		8E8AE8611FE65D1E0015D415 /* FreewordTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8AE8601FE65D1E0015D415 /* FreewordTableViewCell.swift */; };
 		8E8AE8631FEEC1E20015D415 /* ShopDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8AE8621FEEC1E20015D415 /* ShopDetailViewController.swift */; };
@@ -34,6 +35,7 @@
 		8E2625B91FCDBD4C0041010B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8E2625BC1FCDBD4C0041010B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8E2625BE1FCDBD4C0041010B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8E79CEE41FF5E292001957B3 /* ShopPhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopPhoto.swift; sourceTree = "<group>"; };
 		8E8AE85E1FE65A6B0015D415 /* SearchTopTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTopTableViewController.swift; sourceTree = "<group>"; };
 		8E8AE8601FE65D1E0015D415 /* FreewordTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreewordTableViewCell.swift; sourceTree = "<group>"; };
 		8E8AE8621FEEC1E20015D415 /* ShopDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopDetailViewController.swift; sourceTree = "<group>"; };
@@ -132,6 +134,7 @@
 				8EBA6C6A1FDC365E00D516AE /* YahooLocal.swift */,
 				8E8AE8641FEF65250015D415 /* Favorite.swift */,
 				8E8AE86E1FF3DD120015D415 /* LocationService.swift */,
+				8E79CEE41FF5E292001957B3 /* ShopPhoto.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -289,6 +292,7 @@
 				8E8AE86B1FEFABA60015D415 /* FavoriteNavigationController.swift in Sources */,
 				8E8AE85F1FE65A6B0015D415 /* SearchTopTableViewController.swift in Sources */,
 				8E8AE86F1FF3DD120015D415 /* LocationService.swift in Sources */,
+				8E79CEE51FF5E292001957B3 /* ShopPhoto.swift in Sources */,
 				8E8AE8691FEFAB900015D415 /* SearchNavigationController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GourmetSearch/Base.lproj/Main.storyboard
+++ b/GourmetSearch/Base.lproj/Main.storyboard
@@ -460,6 +460,13 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="AAr-Pg-o3L"/>
                     </view>
+                    <navigationItem key="navigationItem" id="Bhv-i5-ogd">
+                        <barButtonItem key="rightBarButtonItem" title="写真を追加" id="8BA-m7-HKk">
+                            <connections>
+                                <action selector="addPhotoTapped:" destination="Wlc-MN-PBp" id="nsk-2D-ZNp"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="address" destination="xRm-hj-woB" id="rGM-Gw-TIb"/>
                         <outlet property="addressContainerHeight" destination="yae-dT-p7v" id="K35-EE-Woe"/>

--- a/GourmetSearch/Common/ShopPhoto.swift
+++ b/GourmetSearch/Common/ShopPhoto.swift
@@ -1,0 +1,123 @@
+//
+//  ShopPhoto.swift
+//  GourmetSearch
+//
+//  Created by Yasunari Kondo on 2017/12/29.
+//  Copyright © 2017年 Yasunari Kondo. All rights reserved.
+//
+
+import Foundation
+
+public class ShopPhoto {
+    var photos = [String: [String]]()
+    var names = [String: String]()
+    var gids = [String]()
+    let path: URL
+
+    static let sharedInstance = ShopPhoto()
+
+    private init() {
+        path = try! FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+
+        load()
+    }
+
+    private func load() {
+        photos.removeAll()
+        names.removeAll()
+        gids.removeAll()
+
+        let ud = UserDefaults.standard
+        ud.register(
+            defaults: [
+                "photos": [String: [String]](),
+                "names": [String: String](),
+                "gids": [String]()
+            ]
+        )
+        ud.synchronize()
+
+        if let photos = ud.object(forKey: "photos") as? [String: [String]] {
+            self.photos = photos
+        }
+        if let names = ud.object(forKey: "names") as? [String: String] {
+            self.names = names
+        }
+        if let gids = ud.object(forKey: "gids") as? [String] {
+            self.gids = gids
+        }
+    }
+
+    private func save() {
+        let ud = UserDefaults.standard
+        ud.set(photos, forKey: "photos")
+        ud.set(names, forKey: "names")
+        ud.set(gids, forKey: "gids")
+        ud.synchronize()
+    }
+
+    public func append(shop: Shop, image: UIImage) {
+        if shop.gid == nil { return }
+        if shop.name == nil { return }
+
+        guard let data = UIImageJPEGRepresentation(image, 0.8) else {
+            return
+        }
+
+        let filename = NSUUID().uuidString + ".jpg"
+        let fileURL = path.appendingPathComponent(filename)
+
+        do {
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            print(error)
+            return
+        }
+
+        if photos[shop.gid!] == nil {
+            photos[shop.gid!] = [String]()
+        } else {
+            gids = gids.filter { $0 != shop.gid! }
+        }
+        gids.append(shop.gid!)
+        photos[shop.gid!]?.append(filename)
+        names[shop.gid!] = shop.name
+
+        save()
+    }
+
+    public func image(gid: String, index: Int) -> UIImage {
+        if photos[gid] == nil { return UIImage() }
+        guard let photoCount = photos[gid]?.count else { return UIImage() }
+        if index >= photoCount { return UIImage() }
+
+        if let filename = photos[gid]?[index] {
+            let fileURL = path.appendingPathComponent(filename)
+            guard let data = try? Data(contentsOf: fileURL) else {
+                return UIImage()
+            }
+            if let image = UIImage(data: data) {
+                return image
+            }
+        }
+        return UIImage()
+    }
+
+    public func count(gid: String) -> Int {
+        if photos[gid] == nil { return 0 }
+        return photos[gid]!.count
+    }
+
+    public func numberOfPhotos(in index: Int) -> Int {
+        if index >= gids.count { return 0 }
+        if let photos = photos[gids[index]] {
+            return photos.count
+        }
+        return 0
+    }
+}

--- a/GourmetSearch/Info.plist
+++ b/GourmetSearch/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>店舗写真を追加するのに使用します。</string>
+	<key>NSCameraUsageDescription</key>
+	<string>店舗写真を追加するのに使用します。</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>店舗地図で現在地を表示するために使用します。</string>
 	<key>NSAppTransportSecurity</key>

--- a/GourmetSearch/ShopList/ShopDetailViewController.swift
+++ b/GourmetSearch/ShopList/ShopDetailViewController.swift
@@ -168,6 +168,10 @@ extension ShopDetailViewController: UIImagePickerControllerDelegate, UINavigatio
     }
 
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
+        if let image = info[UIImagePickerControllerEditedImage] as? UIImage {
+            ShopPhoto.sharedInstance.append(shop: shop, image: image)
+        }
+
         ipc.dismiss(animated: true, completion: nil)
     }
 

--- a/GourmetSearch/ShopList/ShopDetailViewController.swift
+++ b/GourmetSearch/ShopList/ShopDetailViewController.swift
@@ -24,9 +24,14 @@ class ShopDetailViewController: UIViewController {
     
     var shop = Shop()
 
+    let ipc = UIImagePickerController()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configure()
+
+        self.ipc.delegate = self
+        self.ipc.allowsEditing = true
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -111,6 +116,32 @@ class ShopDetailViewController: UIViewController {
         updateFavoriteButton()
     }
     
+    @IBAction func addPhotoTapped(_ sender: UIBarButtonItem) {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+            alert.addAction(UIAlertAction(
+                title: "写真を撮る",
+                style: .default,
+                handler: { action in
+                    self.ipc.sourceType = .camera
+                    self.present(self.ipc, animated: true, completion: nil)
+            }))
+        }
+
+        alert.addAction(UIAlertAction(
+            title: "写真を選択",
+            style: .default,
+            handler: { action in
+                self.ipc.sourceType = .photoLibrary
+                self.present(self.ipc, animated: true, completion: nil)
+        }))
+
+        alert.addAction(UIAlertAction(title: "キャンセル", style: .cancel, handler: { action in }))
+
+        self.present(alert, animated: true, completion: nil)
+    }
+
     // MARK: - Navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "PushMapDetail" {
@@ -129,4 +160,15 @@ extension ShopDetailViewController: UIScrollViewDelegate {
         }
         
     }
+}
+
+extension ShopDetailViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        ipc.dismiss(animated: true, completion: nil)
+    }
+
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
+        ipc.dismiss(animated: true, completion: nil)
+    }
+
 }


### PR DESCRIPTION
### UINavigationControllerDelegate
UIImagePickerControllerDelegateで内部的に使っているのでUIImagePickerControllerDelegateを使用する時はセットで準拠しないといけない

### UIImagePickerController
カメラロール(`sourceType = .photoLibrary`)を開いたり、カメラ(`sourceType = .camera`)を起動する
#### UIImagePickerControllerDelegate
##### imagePickerControllerDidCancel(_ picker: UIImagePickerController)
キャンセル時に呼ばれる
##### imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any])
infoに画像が入っている ↓
```
▿ 6 elements
  ▿ 0 : 2 elements
    - key : "UIImagePickerControllerEditedImage"
    - value : <UIImage: 0x6040020a32a0> size {1236, 822} orientation 0 scale 1.000000
  ▿ 1 : 2 elements
    - key : "UIImagePickerControllerImageURL"
    - value : file:///Users/hoge/Library/Developer/CoreSimulator/Devices/A476E514-EBB2-45F0-A8B8-9570CB973351/data/Containers/Data/Application/9004A548-1409-4C3A-B7DF-88A10E826CD4/tmp/1FEF0A2B-82EB-4D82-B044-8D5421F7AE04.jpeg
  ▿ 2 : 2 elements
    - key : "UIImagePickerControllerMediaType"
    - value : public.image
  ▿ 3 : 2 elements
    - key : "UIImagePickerControllerCropRect"
    - value : NSRect: {{0, 0}, {3065, 2040.5797101449273}}
  ▿ 4 : 2 elements
    - key : "UIImagePickerControllerReferenceURL"
    - value : assets-library://asset/asset.JPG?id=106E99A1-4F6A-45A2-B320-B0AD4A8E8473&ext=JPG
  ▿ 5 : 2 elements
    - key : "UIImagePickerControllerOriginalImage"
    - value : <UIImage: 0x6000010a51c0> size {4288, 2848} orientation 0 scale 1.000000
```

### FileManager
### UserDefaults
### Dataクラス
#### write(to:,options:)
ファイル書き込み
#### Data(contentsOf: fileURL)
ファイル読み込み
### UIImageJPEGRepresentation

